### PR TITLE
Added checks for exposed Drupal configuration files

### DIFF
--- a/dscan/plugins/drupal.py
+++ b/dscan/plugins/drupal.py
@@ -23,6 +23,9 @@ class Drupal(BasePlugin):
     interesting_urls = [
             ("CHANGELOG.txt", "Default changelog file"),
             ("user/login", "Default admin"),
+            ("sites/sites.php", "Multi-site configuration file"),
+            ("sites/default/settings.php", "Drupal secrets file"),
+            ("sites/default/services.yml", "Service configuration file"),
         ]
 
     interesting_module_urls = [


### PR DESCRIPTION
Hi!

I added a few "interesting" URLs to the Drupal plugin. During a recent pentest, we found that the client had misconfigured these sensitive files with read permissions. Thought these would be worthwhile to add to droopescan.

Thank you!

Jake