### PR TITLE
Adding support for additional modules urls in drupal 8

### DIFF
--- a/dscan/plugins/drupal.py
+++ b/dscan/plugins/drupal.py
@@ -9,6 +9,7 @@ class Drupal(BasePlugin):
     plugins_base_url = [
             "%ssites/all/modules/%s/",
             "%ssites/default/modules/%s/",
+            "%smodules/contrib/%s/",
             "%smodules/%s/"]
     themes_base_url = [
             "%ssites/all/themes/%s/",


### PR DESCRIPTION
In Drupal 8, there is an additional url path for the modules. Adding them for scanning.
