### PR TITLE
changing docker image to older python version that is still compatible

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Dockerfile for droope/droopescan
 # License AGPL
-FROM python:3
+FROM python:3.9-bullseye
 
 LABEL org.label-schema.name="droopescan" \
     org.label-schema.description="A plugin-based scanner that aids security researchers in identifying issues with several CMS." \


### PR DESCRIPTION
Hi,
I just noted that the Dockerfile does not run in it's current configuration. It will crash at runtime with a python imp module message. This pull request fixes that, by specifying a specific (older) python base image.